### PR TITLE
chore(buzz): temporarily log buzz-acp relay frames at debug

### DIFF
--- a/clusters/main/kubernetes/apps/buzz/app/fizz-agent.yaml
+++ b/clusters/main/kubernetes/apps/buzz/app/fizz-agent.yaml
@@ -89,6 +89,12 @@ spec:
             # the relay's RELAY_OWNER_PUBKEY.)
             - name: BUZZ_ACP_AGENT_OWNER
               value: "1d17ef66780c2ffceaa4249490e9ec8f3d2084bf4928c21c0c8ac089f4aa77b0"
+            # TEMPORARY (delivery debugging): buzz-acp logs relay frames at debug.
+            # Live `kubectl set env` patches are reverted by Flux within ~2min, so
+            # this has to live in git to survive. Revert once live-event delivery
+            # to this pod is confirmed working.
+            - name: RUST_LOG
+              value: "buzz_acp=debug"
             # ── buzz-agent : brain → LLM ───────────────────────────────────
             - name: BUZZ_AGENT_PROVIDER
               value: "anthropic"


### PR DESCRIPTION
Live-event delivery to the fizz-agent pod is unconfirmed: the pod holds an authenticated, EOSE-acknowledged subscription to `general` but no EVENT frame has been observed arriving. At the default INFO level there is nothing to distinguish "frame never arrived" from "frame arrived and was filtered".

`kubectl set env` is not usable here — Flux reverts the patch within ~2min — so the log level has to be set in git.

Revert once delivery is confirmed.