### PR TITLE
fix(buzz): give cluster Fizz its toolbelt (buzz-dev-mcp)

### DIFF
--- a/clusters/main/kubernetes/apps/buzz/app/fizz-agent.yaml
+++ b/clusters/main/kubernetes/apps/buzz/app/fizz-agent.yaml
@@ -89,6 +89,22 @@ spec:
             # the relay's RELAY_OWNER_PUBKEY.)
             - name: BUZZ_ACP_AGENT_OWNER
               value: "1d17ef66780c2ffceaa4249490e9ec8f3d2084bf4928c21c0c8ac089f4aa77b0"
+            # buzz-agent's ONLY built-in tool is load_skill. Shell, file r/w, rg,
+            # tree, todo — and therefore any ability to run the `buzz` CLI and
+            # post a reply — all arrive over MCP from the buzz-dev-mcp sidecar.
+            # Desktop sets this automatically for the buzz-agent runtime
+            # (desktop/.../managed_agents/discovery.rs → mcp_command:
+            # Some("buzz-dev-mcp")); a Deployment has to say it out loud.
+            # Without it the agent receives mentions, thinks, and cannot speak:
+            # turns end outcome="ok" having published nothing. Requires the
+            # buzz-dev-mcp binary in the image (>= prod-0.2).
+            - name: BUZZ_ACP_MCP_COMMAND
+              value: "buzz-dev-mcp"
+            # Enables the MCP hook tools (_Stop, _PostCompact). The buzz-agent
+            # runtime entry sets mcp_hooks: true; "*" matches because the server
+            # name is hard-coded to "buzz-mcp".
+            - name: MCP_HOOK_SERVERS
+              value: "*"
             # TEMPORARY (delivery debugging): buzz-acp logs relay frames at debug.
             # Live `kubectl set env` patches are reverted by Flux within ~2min, so
             # this has to live in git to survive. Revert once live-event delivery


### PR DESCRIPTION
The fizz-agent pod receives mentions and cannot answer them. Both of the owner's test messages (00:20:06 mobile, 00:22:28 desktop) were delivered to the pod, claimed, and dispatched — `agent_claimed` → `agent_returned outcome="ok"` — with nothing published. Live-event delivery was never the problem.

buzz-agent's only built-in tool is `load_skill`
(crates/buzz-agent/src/builtin.rs:13). Shell, file read/write, rg, tree and todo — and therefore any ability to invoke the `buzz` CLI and post a reply — all arrive over MCP from the buzz-dev-mcp sidecar. buzz-acp's `build_mcp_servers()` returns an empty vec when BUZZ_ACP_MCP_COMMAND is unset (crates/buzz-acp/src/lib.rs:4141-4144), so `session/new` carried `"mcpServers": []` and the agent had no way to speak. A ~25s turn that publishes nothing is exactly the signature of a toolless agent: one LLM round, no tool to call, turn over.

Buzz Desktop sets this automatically — the `buzz-agent` runtime entry declares `mcp_command: Some("buzz-dev-mcp")` and `mcp_hooks: true` (desktop/src-tauri/src/managed_agents/discovery.rs:164-171), passed through as BUZZ_ACP_MCP_COMMAND / MCP_HOOK_SERVERS in runtime.rs:1727. A Deployment has to declare it explicitly.

Requires buzz-agent-host >= prod-0.2: the prod image was built with only buzz-acp, buzz-agent and buzz-cli, so the buzz-dev-mcp binary is absent from the current image. prod-0.2 adds it, built from the same upstream commit (b8510ed) as prod — the added binary is the only difference. The :prod channel tag is republished to the same image, so imagePullPolicy: Always picks it up on the rollout this change triggers.

RUST_LOG=buzz_acp=debug is deliberately left in place until the pod is observed publishing a reply; it goes away in the follow-up revert.