### PR TITLE
fix(buzz): give cluster Fizz a persona; bump model to Sonnet 5

### DIFF
--- a/clusters/main/kubernetes/apps/buzz/app/fizz-agent.yaml
+++ b/clusters/main/kubernetes/apps/buzz/app/fizz-agent.yaml
@@ -105,6 +105,25 @@ spec:
             # name is hard-coded to "buzz-mcp".
             - name: MCP_HOOK_SERVERS
               value: "*"
+            # The agent's persona. Without this, config.system_prompt is None and
+            # buzz-agent falls back to its own generic default — the compiled-in
+            # [Base] harness prompt (buzz-acp/src/base_prompt.md, include_str!) is
+            # always present, but there is no "you are Fizz" block at all. Desktop
+            # sends this automatically from the saved agent definition; a
+            # Deployment has to say it out loud. Suspected cause of cold-session
+            # turns that make zero tool calls and publish nothing.
+            # NOTE: no `$` anywhere in this value — Flux envsubst runs over it.
+            - name: BUZZ_ACP_SYSTEM_PROMPT
+              value: |-
+                You are Fizz (display name Fizzman), an energetic maker who turns
+                ideas into action. Be upbeat, practical, and decisive. Help users
+                plan, create, solve problems, and finish work. Add occasional bee
+                wordplay or 🐝✨ — keep it charming, never distracting.
+
+                This instance runs in the Talos cluster: pod fizz-agent, namespace
+                buzz, working directory /var/lib/buzz. There is no kubectl binary
+                and no kubeconfig here. Say that plainly when asked to do cluster
+                work — never claim to be the Desktop host on the Mac.
             # TEMPORARY (delivery debugging): buzz-acp logs relay frames at debug.
             # Live `kubectl set env` patches are reverted by Flux within ~2min, so
             # this has to live in git to survive. Revert once live-event delivery
@@ -114,8 +133,16 @@ spec:
             # ── buzz-agent : brain → LLM ───────────────────────────────────
             - name: BUZZ_AGENT_PROVIDER
               value: "anthropic"
+            # Sonnet 5 — near-Opus quality on agentic/tool work at Sonnet cost
+            # (3.00/15.00 per MTok; intro 2.00/10.00 through 2026-08-31).
+            # Safe for buzz-agent: it sends no temperature/top_p/top_k (which
+            # Sonnet 5 rejects), and omits `thinking` entirely while
+            # BUZZ_AGENT_THINKING_EFFORT is unset.
+            # ⚠️ Do NOT switch to claude-opus-5 without a buzz-agent fix: it is
+            # missing from is_adaptive_thinking_model() (buzz-agent/src/config.rs
+            # :603), so setting a thinking effort would send budget_tokens and 400.
             - name: ANTHROPIC_MODEL
-              value: "claude-sonnet-4-5"     # or an Opus API id
+              value: "claude-sonnet-5"
             # ── secrets via clusterenv (${...} → Flux substituteFrom cluster-config) ──
             - name: ANTHROPIC_API_KEY
               value: "${ANTHROPIC_KEY}"       # owner adds ANTHROPIC_KEY to clusterenv.yaml


### PR DESCRIPTION
The fizz-agent pod has been running with no persona at all. `BUZZ_ACP_SYSTEM_PROMPT` was never set and there is no command/args override, so buzz-acp passes `system_prompt: None` (crates/buzz-acp/src/lib.rs:1537) and buzz-agent falls back to its own generic default (crates/buzz-agent/src/lib.rs:365-368). The compiled-in [Base] harness prompt is always present — it is `include_str!("base_prompt.md")` (lib.rs:1544) — so the pod knew the Buzz operating rules, but nothing told it it was Fizz. Buzz Desktop sends this field automatically from the saved agent definition; a Deployment has to declare it.

This is the leading suspect for the cold-session silent turn. Observed 4/4 tonight across two pod boots: the first turn of a fresh agent session makes zero `tool call started` calls and returns `agent_returned outcome="ok"` having published nothing (00:58:01, 01:53:14), while every warm turn on the same slot makes 9-10 tool calls and publishes (01:00:17, 01:57:34). buzz-acp never publishes an agent's final text — only what it sends via a tool — so a turn that answers conversationally instead of calling `buzz messages send` is silent, with no error logged anywhere. Not proven: verify by confirming a *cold* turn replies after this lands.

Ruled out first: the MCP handshake is not racing the first prompt. `McpRegistry::spawn_all(&app.cfg, &p.mcp_servers, &p.cwd).await` completes before `session/new` returns (crates/buzz-agent/src/lib.rs:390), so tools are registered on turn 1.

Also bumps ANTHROPIC_MODEL from claude-sonnet-4-5 to claude-sonnet-5 — near-Opus quality on agentic and tool-calling work, which is what this pod does all day. Verified safe for buzz-agent, which is stricter than Sonnet 5 requires: it sends no temperature/top_p/top_k (Sonnet 5 rejects non-default values), and omits `thinking` entirely while BUZZ_AGENT_THINKING_EFFORT is unset. claude-sonnet-5 is in `is_adaptive_thinking_model()` (crates/buzz-agent/src/config.rs:610), so if an effort is set later it correctly emits the adaptive shape rather than the removed `budget_tokens`. claude-opus-5 is NOT in that list and would emit `budget_tokens` (a 400) — noted inline so the next person does not walk into it.

Deploying this needs `flux resume kustomization buzz -n flux-system`; the buzz kustomization is still suspended from turning the pod off earlier tonight.